### PR TITLE
Trim down the agent skills, let agents auto-discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ohdear list-tags                 # List all tags
 ohdear clear-cache               # Clear cached OpenAPI spec
 ```
 
-All commands output JSON. Run `ohdear <command> --help` for full parameter details.
+By default, commands output human-readable text. Add `--json` for JSON output. Run `ohdear <command> --help` for full parameter details.
 
 ## AI Skill
 

--- a/skills/ohdear/SKILL.md
+++ b/skills/ohdear/SKILL.md
@@ -2,11 +2,13 @@
 name: ohdear
 description: >-
   Manage Oh Dear website monitoring using the ohdear CLI.
-  Use when the user wants to list, add, or manage monitors; check uptime and
-  downtime; view broken links, mixed content, or certificate health; manage
-  maintenance periods and status pages; configure cron checks; view DNS history;
-  check application health; view Lighthouse reports; manage tags; or interact
-  with ohdear.app from the command line.
+  Use when the user wants to check if their site is up, view uptime or downtime,
+  list or manage monitors, view broken links, mixed content, or certificate health,
+  manage maintenance periods or status pages, configure cron checks, view DNS
+  history or DNS blocklists, check port scan results, view sitemap checks,
+  check application health, view Lighthouse performance reports, manage tags,
+  manage notification destinations, manage teams, or interact with ohdear.app
+  in any way.
 license: MIT
 metadata:
   author: ohdearapp
@@ -15,291 +17,58 @@ metadata:
 
 # Oh Dear CLI
 
-The `ohdear` CLI lets you manage [Oh Dear](https://ohdear.app) website monitoring from the terminal. Every Oh Dear API endpoint has a corresponding command.
+The `ohdear` CLI manages [Oh Dear](https://ohdear.app) website monitoring from the terminal. Every Oh Dear API endpoint has a corresponding command.
 
 ## Prerequisites
 
-Check that the CLI is installed:
-
 ```bash
-ohdear --version
-```
-
-If not installed:
-
-```bash
-composer global require ohdearapp/ohdear-cli
-```
-
-Ensure Composer's global bin directory is in `PATH`:
-
-```bash
-composer global config bin-dir --absolute
+ohdear --version  # Check if installed
+composer global require ohdearapp/ohdear-cli  # Install if needed
 ```
 
 ## Authentication
 
 ```bash
-# Log in (you'll be prompted for your API token)
-ohdear login
-
-# Log out
-ohdear logout
+ohdear login   # Prompted for API token (get it at https://ohdear.app/user-settings/api)
+ohdear logout  # Clear credentials
 ```
 
-Get your API token at https://ohdear.app/user-settings/api.
+If any command returns 401, run `ohdear login` again.
 
-If any command returns a 401 error, the token is invalid or expired. Run `ohdear login` again.
-
-## Quick command reference
-
-All commands output JSON. See [references/commands.md](references/commands.md) for full parameter details.
-
-### User
+## Discovering commands
 
 ```bash
-# Who am I?
-ohdear get-me
+ohdear list              # List all available commands
+ohdear <command> --help  # Get help for a specific command
 ```
 
-### Monitors
-
-```bash
-# List all monitors
-ohdear list-monitors
-
-# Get a specific monitor
-ohdear get-monitor --monitor-id=123
-
-# Add a new monitor
-ohdear create-monitor --field url="https://example.com" --field team_id=1
-
-# Update a monitor
-ohdear update-monitor --monitor-id=123 --field friendly_name="My Site"
-
-# Delete a monitor
-ohdear delete-monitor --monitor-id=123
-```
-
-### Checks
-
-```bash
-# Get check summary for a monitor
-ohdear get-check-summary --monitor-id=123
-
-# Enable/disable a check
-ohdear enable-check --check-id=456
-ohdear disable-check --check-id=456
-
-# Request a check run
-ohdear request-check-run --check-id=456
-
-# Snooze/unsnooze a check
-ohdear snooze-check --check-id=456 --field minutes=60
-ohdear unsnooze-check --check-id=456
-```
-
-### Uptime and downtime
-
-```bash
-# Get uptime data
-ohdear get-uptime --monitor-id=123
-
-# Get downtime data
-ohdear get-downtime --monitor-id=123
-
-# Delete a downtime record
-ohdear delete-downtime --downtime-id=789
-
-# Get uptime metrics
-ohdear http-uptime-metrics --monitor-id=123
-ohdear ping-uptime-metrics --monitor-id=123
-ohdear tcp-uptime-metrics --monitor-id=123
-```
-
-### Broken links and mixed content
-
-```bash
-# List broken links for a monitor
-ohdear list-broken-links --monitor-id=123
-
-# Add a broken link whitelist URL
-ohdear add-broken-links-whitelist-url --monitor-id=123 --field url="https://example.com/old"
-
-# List mixed content
-ohdear list-mixed-content --monitor-id=123
-```
-
-### Certificate health
-
-```bash
-# Get certificate health
-ohdear get-certificate-health --monitor-id=123
-
-# List detected certificates
-ohdear list-detected-certificates --monitor-id=123
-
-# Get a specific detected certificate
-ohdear get-detected-certificate --detected-certificate-id=456
-```
-
-### Maintenance periods
-
-```bash
-# List maintenance periods
-ohdear list-maintenance-periods --monitor-id=123
-
-# Start/stop maintenance
-ohdear start-maintenance --monitor-id=123
-ohdear stop-maintenance --monitor-id=123
-
-# Create a scheduled maintenance period
-ohdear create-maintenance-period --monitor-id=123 --field start_date="2025-01-01 00:00:00" --field end_date="2025-01-01 06:00:00"
-
-# Delete a maintenance period
-ohdear delete-maintenance-period --maintenance-period-id=789
-```
-
-### Status pages
-
-```bash
-# List status pages
-ohdear list-status-pages
-
-# Create a status page
-ohdear create-status-page --field title="Status" --field team_id=1
-
-# Get a specific status page
-ohdear get-status-page --status-page-id=123
-
-# Delete a status page
-ohdear delete-status-page --status-page-id=123
-
-# Add/remove monitors from a status page
-ohdear add-status-page-monitors --status-page-id=123 --field monitor_ids="[1,2,3]"
-ohdear remove-status-page-monitor --status-page-id=123 --monitor-id=456
-```
-
-### Status page updates
-
-```bash
-# List updates for a status page
-ohdear list-status-page-updates --status-page-id=123
-
-# Create a status page update
-ohdear create-status-page-update --status-page-id=123 --field title="Investigating issue" --field text="We are investigating."
-
-# Update an existing update
-ohdear update-status-page-update --status-page-update-id=456 --field title="Resolved"
-
-# Delete a status page update
-ohdear delete-status-page-update --status-page-update-id=456
-```
-
-### Cron checks
-
-```bash
-# List cron checks for a monitor
-ohdear list-cron-checks --monitor-id=123
-
-# Create a cron check
-ohdear create-cron-check --monitor-id=123 --field name="Daily Backup" --field frequency_in_minutes=1440
-
-# Update/delete a cron check
-ohdear update-cron-check --cron-check-id=456 --field name="Updated Check"
-ohdear delete-cron-check --cron-check-id=456
-```
-
-### DNS and domain info
-
-```bash
-# Get DNS history for a monitor
-ohdear get-dns-history --monitor-id=123
-
-# Get domain info for a monitor
-ohdear get-domain-info --monitor-id=123
-```
-
-### Application health
-
-```bash
-# List application health checks
-ohdear list-application-health-checks --monitor-id=123
-
-# Get application health check history
-ohdear get-application-health-check-history --application-health-check-id=456
-
-# Snooze/unsnooze an application health check
-ohdear snooze-application-health-check --application-health-check-id=456
-ohdear unsnooze-application-health-check --application-health-check-id=456
-```
-
-### Lighthouse reports
-
-```bash
-# List Lighthouse reports for a monitor
-ohdear list-lighthouse-reports --monitor-id=123
-
-# Get the latest Lighthouse report
-ohdear get-latest-lighthouse-report --monitor-id=123
-
-# Get a specific Lighthouse report
-ohdear get-lighthouse-report --lighthouse-report-id=456
-```
-
-### AI responses
-
-```bash
-# List AI responses for a monitor
-ohdear list-ai-responses --monitor-id=123
-
-# Get the latest AI response
-ohdear get-latest-ai-response --monitor-id=123
-
-# Get a specific AI response
-ohdear get-ai-response --ai-response-id=456
-```
-
-### Tags
-
-```bash
-# List all tags
-ohdear list-tags
-
-# Create a tag
-ohdear create-tag --field name="production"
-
-# List tag groups
-ohdear list-tag-groups
-
-# Create/update/delete a tag group
-ohdear create-tag-group --field name="Environments"
-ohdear update-tag-group --tag-group-id=123 --field name="Updated Group"
-ohdear delete-tag-group --tag-group-id=123
-```
-
-### Notification destinations
-
-```bash
-# List notification destinations for a team
-ohdear list-team-notification-destinations --team-id=1
-
-# Create a notification destination
-ohdear create-team-notification-destination --team-id=1 --field type="slack" --field label="Slack alerts"
-```
-
-## Common workflows
-
-See [references/workflows.md](references/workflows.md) for detailed workflow guides.
+Commands accept `--field key=value` for body params and `--option-name=value` for path/query params.
 
 ## Output format
 
-All commands return JSON. When presenting results to the user:
+By default, commands output human-readable formatted text. Use these flags to change the format:
 
-- **Monitors**: Show as a table with columns: ID, URL, friendly name, status, checks enabled.
-- **Uptime**: Show percentage uptime and any downtime periods with start/end times.
-- **Broken links**: List the broken URLs with their HTTP status codes and the page they were found on.
-- **Certificate health**: Show certificate issuer, expiration date, and any issues found.
-- **Cron checks**: Show name, frequency, last ping time, and status.
-- **Status pages**: Show title, URL, and associated monitors.
-- **Lighthouse reports**: Show performance, accessibility, best practices, and SEO scores.
+| Flag | Output |
+|------|--------|
+| *(default)* | Human-readable tables and lists |
+| `--json` | Pretty-printed JSON |
+| `--yaml` | YAML |
+| `--minify` | Compact JSON (no pretty-printing) |
+| `-H, --headers` | Include response headers |
+
+When presenting results to the user, summarize the human-readable output clearly:
+- **Monitors**: Table with ID, URL, friendly name, status, checks enabled
+- **Uptime**: Percentage uptime and downtime periods with start/end times
+- **Broken links**: URLs with HTTP status codes and source page
+- **Certificate health**: Issuer, expiration date, and issues found
+- **Cron checks**: Name, frequency, last ping time, status
+- **Status pages**: Title, URL, associated monitors
+- **Lighthouse reports**: Performance, accessibility, best practices, SEO scores
+
+## Reference
+
+- **Full command list**: See [references/commands.md](references/commands.md)
+- **Step-by-step workflows**: See [references/workflows.md](references/workflows.md)
+  - Monitor setup, downtime investigation, maintenance windows
+  - Broken link audits, certificate monitoring, status pages
+  - Cron checks, Lighthouse reports, application health, tags

--- a/skills/ohdear/SKILL.md
+++ b/skills/ohdear/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: ohdearapp
-  version: "5.0.0"
+  version: "5.1.3"
 ---
 
 # Oh Dear CLI
@@ -42,21 +42,11 @@ ohdear list              # List all available commands
 ohdear <command> --help  # Get help for a specific command
 ```
 
-Commands accept `--field key=value` for body params and `--option-name=value` for path/query params.
+## Output
 
-## Output format
+By default, commands output human-readable formatted text. Add `--json`, `--yaml`, or `--minify` for machine-readable output. Use `-H` to include response headers.
 
-By default, commands output human-readable formatted text. Use these flags to change the format:
-
-| Flag | Output |
-|------|--------|
-| *(default)* | Human-readable tables and lists |
-| `--json` | Pretty-printed JSON |
-| `--yaml` | YAML |
-| `--minify` | Compact JSON (no pretty-printing) |
-| `-H, --headers` | Include response headers |
-
-When presenting results to the user, summarize the human-readable output clearly:
+When presenting results to the user, summarize clearly:
 - **Monitors**: Table with ID, URL, friendly name, status, checks enabled
 - **Uptime**: Percentage uptime and downtime periods with start/end times
 - **Broken links**: URLs with HTTP status codes and source page

--- a/skills/ohdear/references/commands.md
+++ b/skills/ohdear/references/commands.md
@@ -1,164 +1,36 @@
 # Oh Dear CLI Command Reference
 
-All commands are auto-generated from the Oh Dear OpenAPI specification. They accept `--field key=value` for request body parameters and `--option-name=value` for path/query parameters. All commands output JSON.
+All API commands are auto-generated from the Oh Dear OpenAPI specification. Run `ohdear list` to see all available commands, and `ohdear <command> --help` for parameters and usage.
 
-## Authentication
+Commands accept `--field key=value` for body params and `--option-name=value` for path/query params. Default output is human-readable text; use `--json` for JSON or `--yaml` for YAML.
 
-| Command | Description |
-|---------|-------------|
-| `login` | Store your Oh Dear API token |
-| `logout` | Clear stored credentials |
-| `clear-cache` | Clear cached OpenAPI spec and temp files |
-| `install-skill` | Install the Oh Dear agent skill |
+## Command categories
 
-## User
+| Category | Key commands | Description |
+|----------|-------------|-------------|
+| **Auth** | `login`, `logout`, `clear-cache` | API token management |
+| **User** | `get-me` | Current user info |
+| **Monitors** | `list-monitors`, `create-monitor`, `get-monitor`, `get-monitor-by-url`, `update-monitor`, `delete-monitor` | Full CRUD for monitors |
+| **Checks** | `get-check-summary`, `enable-check`, `disable-check`, `request-check-run`, `snooze-check`, `unsnooze-check` | Enable/disable/snooze individual checks on a monitor |
+| **Uptime & Downtime** | `get-uptime`, `get-downtime`, `http-uptime-metrics`, `ping-uptime-metrics`, `tcp-uptime-metrics`, `get-public-metrics` | Uptime percentages, downtime periods, metrics by protocol |
+| **Broken Links** | `list-broken-links`, `add-broken-links-whitelist-url` | Find broken links, whitelist known URLs |
+| **Mixed Content** | `list-mixed-content` | HTTP resources on HTTPS pages |
+| **Certificate Health** | `get-certificate-health`, `list-detected-certificates`, `get-detected-certificate` | SSL/TLS certificate monitoring |
+| **DNS & Domain** | `get-dns-history`, `get-dns-history-item`, `get-domain-info` | DNS records and domain registration info |
+| **DNS Blocklists** | `list-dns-blocklist-history-items`, `get-dns-blocklist-history-item` | Check if domain is on DNS blocklists |
+| **Port Scanning** | `list-ports-history-items`, `get-ports-history-item` | Open port scan results |
+| **Sitemap** | `get-sitemap-results` | Sitemap validation results |
+| **Maintenance** | `start-maintenance`, `stop-maintenance`, `create-maintenance-period`, `list-maintenance-periods` | Immediate and scheduled maintenance windows |
+| **Recurring Maintenance** | `list-recurring-maintenance-periods`, `create-recurring-maintenance-period` | Repeating maintenance schedules (full CRUD) |
+| **Status Pages** | `list-status-pages`, `create-status-page`, `add-status-page-monitors` | Public status pages with monitor assignments |
+| **Status Page Updates** | `list-status-page-updates`, `create-status-page-update` | Incident updates on status pages |
+| **Status Page Templates** | `list-status-page-update-templates`, `create-status-page-update-template` | Reusable templates for status page updates |
+| **Cron Checks** | `list-cron-checks`, `create-cron-check`, `sync-cron-checks`, `snooze-cron-check` | Monitor scheduled tasks/cron jobs |
+| **Application Health** | `list-application-health-checks`, `get-application-health-check-history`, `snooze-application-health-check` | Laravel/app health check monitoring |
+| **Lighthouse** | `list-lighthouse-reports`, `get-latest-lighthouse-report`, `get-lighthouse-report` | Performance, accessibility, SEO scores |
+| **AI Responses** | `list-ai-responses`, `get-latest-ai-response`, `get-ai-response` | AI-generated analysis of check results |
+| **Tags** | `list-tags`, `create-tag`, `list-tag-groups`, `create-tag-group` | Organize monitors with tags and groups |
+| **Notifications** | `list-team-notification-destinations`, `create-team-notification-destination` | Notification destinations at team, monitor, tag, and tag group level (full CRUD at each level) |
+| **Managed Teams** | `list-managed-teams`, `create-managed-team`, `add-user-to-managed-team`, `generate-login-link-for-managed-team-user` | Team management for resellers/agencies |
 
-| Command | Description |
-|---------|-------------|
-| `get-me` | Get the authenticated user |
-
-## Monitors
-
-| Command | Description |
-|---------|-------------|
-| `list-monitors` | List all monitors |
-| `create-monitor` | Create a new monitor |
-| `get-monitor` | Get a specific monitor |
-| `update-monitor` | Update a monitor |
-| `delete-monitor` | Delete a monitor |
-
-## Checks
-
-| Command | Description |
-|---------|-------------|
-| `get-check-summary` | Get check summary for a monitor |
-| `enable-check` | Enable a check |
-| `disable-check` | Disable a check |
-| `request-check-run` | Request a manual check run |
-| `snooze-check` | Snooze a check |
-| `unsnooze-check` | Unsnooze a check |
-
-## Uptime and Downtime
-
-| Command | Description |
-|---------|-------------|
-| `get-uptime` | Get uptime data for a monitor |
-| `get-downtime` | Get downtime data for a monitor |
-| `delete-downtime` | Delete a downtime record |
-| `http-uptime-metrics` | Get HTTP uptime metrics |
-| `ping-uptime-metrics` | Get ping uptime metrics |
-| `tcp-uptime-metrics` | Get TCP uptime metrics |
-
-## Broken Links and Mixed Content
-
-| Command | Description |
-|---------|-------------|
-| `list-broken-links` | List broken links for a monitor |
-| `add-broken-links-whitelist-url` | Whitelist a broken link URL |
-| `list-mixed-content` | List mixed content for a monitor |
-
-## Certificate Health
-
-| Command | Description |
-|---------|-------------|
-| `get-certificate-health` | Get certificate health for a monitor |
-| `list-detected-certificates` | List detected certificates |
-| `get-detected-certificate` | Get a specific detected certificate |
-
-## Maintenance Periods
-
-| Command | Description |
-|---------|-------------|
-| `list-maintenance-periods` | List maintenance periods for a monitor |
-| `start-maintenance` | Start maintenance for a monitor |
-| `stop-maintenance` | Stop maintenance for a monitor |
-| `create-maintenance-period` | Create a scheduled maintenance period |
-| `update-maintenance-period` | Update a maintenance period |
-| `delete-maintenance-period` | Delete a maintenance period |
-
-## Status Pages
-
-| Command | Description |
-|---------|-------------|
-| `list-status-pages` | List all status pages |
-| `create-status-page` | Create a status page |
-| `get-status-page` | Get a specific status page |
-| `delete-status-page` | Delete a status page |
-| `add-status-page-monitors` | Add monitors to a status page |
-| `remove-status-page-monitor` | Remove a monitor from a status page |
-
-## Status Page Updates
-
-| Command | Description |
-|---------|-------------|
-| `list-status-page-updates` | List updates for a status page |
-| `create-status-page-update` | Create a status page update |
-| `update-status-page-update` | Update a status page update |
-| `delete-status-page-update` | Delete a status page update |
-
-## Cron Checks
-
-| Command | Description |
-|---------|-------------|
-| `list-cron-checks` | List cron checks for a monitor |
-| `create-cron-check` | Create a cron check |
-| `sync-cron-checks` | Sync cron checks for a monitor |
-| `update-cron-check` | Update a cron check |
-| `delete-cron-check` | Delete a cron check |
-
-## DNS and Domain
-
-| Command | Description |
-|---------|-------------|
-| `get-dns-history` | Get DNS history for a monitor |
-| `get-domain-info` | Get domain info for a monitor |
-
-## Application Health
-
-| Command | Description |
-|---------|-------------|
-| `list-application-health-checks` | List application health checks |
-| `get-application-health-check-history` | Get health check history |
-| `snooze-application-health-check` | Snooze an application health check |
-| `unsnooze-application-health-check` | Unsnooze an application health check |
-
-## Lighthouse Reports
-
-| Command | Description |
-|---------|-------------|
-| `list-lighthouse-reports` | List Lighthouse reports |
-| `get-latest-lighthouse-report` | Get the latest Lighthouse report |
-| `get-lighthouse-report` | Get a specific Lighthouse report |
-
-## AI Responses
-
-| Command | Description |
-|---------|-------------|
-| `list-ai-responses` | List AI responses for a monitor |
-| `get-latest-ai-response` | Get the latest AI response |
-| `get-ai-response` | Get a specific AI response |
-
-## Tags
-
-| Command | Description |
-|---------|-------------|
-| `list-tags` | List all tags |
-| `create-tag` | Create a tag |
-| `list-tag-groups` | List tag groups |
-| `create-tag-group` | Create a tag group |
-| `update-tag-group` | Update a tag group |
-| `delete-tag-group` | Delete a tag group |
-
-## Notification Destinations
-
-| Command | Description |
-|---------|-------------|
-| `list-team-notification-destinations` | List notification destinations for a team |
-| `create-team-notification-destination` | Create a notification destination |
-
-## Cron Check Snoozing
-
-| Command | Description |
-|---------|-------------|
-| `snooze-cron-check` | Snooze a cron check |
-| `unsnooze-cron-check` | Unsnooze a cron check |
+Most categories follow standard CRUD patterns: `list-*`, `create-*`, `get-*`, `update-*`, `delete-*`. If a command isn't listed above, run `ohdear list` to discover it.

--- a/skills/ohdear/references/commands.md
+++ b/skills/ohdear/references/commands.md
@@ -2,17 +2,17 @@
 
 All API commands are auto-generated from the Oh Dear OpenAPI specification. Run `ohdear list` to see all available commands, and `ohdear <command> --help` for parameters and usage.
 
-Commands accept `--field key=value` for body params and `--option-name=value` for path/query params. Default output is human-readable text; use `--json` for JSON or `--yaml` for YAML.
+Commands accept `--field key=value` for body params and `--option-name=value` for path/query params. Default output is human-readable text; add `--json`, `--yaml`, or `--minify` for machine-readable output.
 
 ## Command categories
 
 | Category | Key commands | Description |
 |----------|-------------|-------------|
-| **Auth** | `login`, `logout`, `clear-cache` | API token management |
+| **Auth & Utility** | `login`, `logout`, `clear-cache`, `install-skill` | API token management and CLI maintenance |
 | **User** | `get-me` | Current user info |
-| **Monitors** | `list-monitors`, `create-monitor`, `get-monitor`, `get-monitor-by-url`, `update-monitor`, `delete-monitor` | Full CRUD for monitors |
+| **Monitors** | `list-monitors`, `create-monitor`, `get-monitor`, `get-monitor-by-url`, `update-monitor`, `delete-monitor` | CRUD for monitors |
 | **Checks** | `get-check-summary`, `enable-check`, `disable-check`, `request-check-run`, `snooze-check`, `unsnooze-check` | Enable/disable/snooze individual checks on a monitor |
-| **Uptime & Downtime** | `get-uptime`, `get-downtime`, `http-uptime-metrics`, `ping-uptime-metrics`, `tcp-uptime-metrics`, `get-public-metrics` | Uptime percentages, downtime periods, metrics by protocol |
+| **Uptime & Downtime** | `get-uptime`, `get-downtime`, `delete-downtime`, `http-uptime-metrics`, `ping-uptime-metrics`, `tcp-uptime-metrics`, `get-public-metrics` | Uptime percentages, downtime periods, metrics by protocol |
 | **Broken Links** | `list-broken-links`, `add-broken-links-whitelist-url` | Find broken links, whitelist known URLs |
 | **Mixed Content** | `list-mixed-content` | HTTP resources on HTTPS pages |
 | **Certificate Health** | `get-certificate-health`, `list-detected-certificates`, `get-detected-certificate` | SSL/TLS certificate monitoring |
@@ -20,17 +20,17 @@ Commands accept `--field key=value` for body params and `--option-name=value` fo
 | **DNS Blocklists** | `list-dns-blocklist-history-items`, `get-dns-blocklist-history-item` | Check if domain is on DNS blocklists |
 | **Port Scanning** | `list-ports-history-items`, `get-ports-history-item` | Open port scan results |
 | **Sitemap** | `get-sitemap-results` | Sitemap validation results |
-| **Maintenance** | `start-maintenance`, `stop-maintenance`, `create-maintenance-period`, `list-maintenance-periods` | Immediate and scheduled maintenance windows |
-| **Recurring Maintenance** | `list-recurring-maintenance-periods`, `create-recurring-maintenance-period` | Repeating maintenance schedules (full CRUD) |
-| **Status Pages** | `list-status-pages`, `create-status-page`, `add-status-page-monitors` | Public status pages with monitor assignments |
-| **Status Page Updates** | `list-status-page-updates`, `create-status-page-update` | Incident updates on status pages |
-| **Status Page Templates** | `list-status-page-update-templates`, `create-status-page-update-template` | Reusable templates for status page updates |
-| **Cron Checks** | `list-cron-checks`, `create-cron-check`, `sync-cron-checks`, `snooze-cron-check` | Monitor scheduled tasks/cron jobs |
+| **Maintenance** | `start-maintenance`, `stop-maintenance`, `list-maintenance-periods`, `create-maintenance-period` | Immediate and scheduled maintenance windows (CRUD) |
+| **Recurring Maintenance** | `list-recurring-maintenance-periods`, `create-recurring-maintenance-period` | Repeating maintenance schedules (CRUD) |
+| **Status Pages** | `list-status-pages`, `create-status-page`, `get-status-page`, `add-status-page-monitors`, `remove-status-page-monitor` | Public status pages with monitor assignments (CRUD) |
+| **Status Page Updates** | `list-status-page-updates`, `create-status-page-update`, `update-status-page-update` | Incident updates on status pages (CRUD) |
+| **Status Page Templates** | `list-status-page-update-templates`, `create-status-page-update-template` | Reusable templates for status page updates (CRUD) |
+| **Cron Checks** | `list-cron-checks`, `create-cron-check`, `sync-cron-checks`, `snooze-cron-check` | Monitor scheduled tasks/cron jobs (CRUD) |
 | **Application Health** | `list-application-health-checks`, `get-application-health-check-history`, `snooze-application-health-check` | Laravel/app health check monitoring |
 | **Lighthouse** | `list-lighthouse-reports`, `get-latest-lighthouse-report`, `get-lighthouse-report` | Performance, accessibility, SEO scores |
 | **AI Responses** | `list-ai-responses`, `get-latest-ai-response`, `get-ai-response` | AI-generated analysis of check results |
-| **Tags** | `list-tags`, `create-tag`, `list-tag-groups`, `create-tag-group` | Organize monitors with tags and groups |
-| **Notifications** | `list-team-notification-destinations`, `create-team-notification-destination` | Notification destinations at team, monitor, tag, and tag group level (full CRUD at each level) |
-| **Managed Teams** | `list-managed-teams`, `create-managed-team`, `add-user-to-managed-team`, `generate-login-link-for-managed-team-user` | Team management for resellers/agencies |
+| **Tags** | `list-tags`, `create-tag`, `list-tag-groups`, `create-tag-group` | Organize monitors with tags and groups (CRUD) |
+| **Notifications** | `list-team-notification-destinations`, `create-team-notification-destination` | Notification destinations at team, monitor, tag, and tag group level (CRUD at each scope — use `ohdear list` for all variants) |
+| **Managed Teams** | `list-managed-teams`, `create-managed-team`, `add-user-to-managed-team`, `generate-login-link-for-managed-team-user` | Team management for resellers/agencies (CRUD) |
 
-Most categories follow standard CRUD patterns: `list-*`, `create-*`, `get-*`, `update-*`, `delete-*`. If a command isn't listed above, run `ohdear list` to discover it.
+Categories marked (CRUD) also have `get-*`, `update-*`, `delete-*` variants. Run `ohdear list` to discover all commands.

--- a/skills/ohdear/references/workflows.md
+++ b/skills/ohdear/references/workflows.md
@@ -84,8 +84,8 @@ ohdear start-maintenance --monitor-id=<id>
 
 ```bash
 ohdear create-maintenance-period --monitor-id=<id> \
-  --field start_date="2025-06-01 02:00:00" \
-  --field end_date="2025-06-01 06:00:00"
+  --field start_date="2026-07-01 02:00:00" \
+  --field end_date="2026-07-01 06:00:00"
 ```
 
 ### 3. List current maintenance periods


### PR DESCRIPTION
## Why

The agent skill was bloating context windows by inlining every CLI command with full examples (~306 lines), duplicating what the reference files and the CLI's own `--help` already provide. CLI-wrapping skills should teach agents to discover commands, not enumerate them.

## What changed

- Rewrote SKILL.md to use progressive disclosure: auth, discovery instructions (`ohdear list` / `--help`), output format, and pointers to reference files. 306 lines down to 65.
- Rebuilt commands.md as a category index with key commands per group instead of exhaustive per-command tables. Added 39 previously missing commands across 6 new categories (DNS blocklists, port scanning, sitemap, recurring maintenance, status page templates, managed teams).
- Fixed incorrect "All commands output JSON" claim everywhere (SKILL.md, commands.md, README.md) — default is human-readable text, `--json` is opt-in.
- Updated stale metadata (version 5.0.0 to 5.1.3) and example dates.
